### PR TITLE
Add configurable EZID action for minting ARKs from content page (Issue 28)

### DIFF
--- a/modules/dgi_actions_ark_identifier/src/Plugin/Action/MintArkIdentifierNode.php
+++ b/modules/dgi_actions_ark_identifier/src/Plugin/Action/MintArkIdentifierNode.php
@@ -11,4 +11,4 @@ namespace Drupal\dgi_actions_ark_identifier\Plugin\Action;
  *   type = "node"
  * )
  */
-class MintArkIdentifierNode extends MintArkIdentifier { }
+class MintArkIdentifierNode extends MintArkIdentifier {}

--- a/modules/dgi_actions_ark_identifier/src/Plugin/Action/MintArkIdentifierNode.php
+++ b/modules/dgi_actions_ark_identifier/src/Plugin/Action/MintArkIdentifierNode.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Drupal\dgi_actions_ark_identifier\Plugin\Action;
+
+/**
+ * Mints an ARK Identifier Record on CDL EZID.
+ *
+ * @Action(
+ *   id = "dgi_actions_mint_ark_identifier_node",
+ *   label = @Translation("Mint ARK EZID Identifier for Node"),
+ *   type = "node"
+ * )
+ */
+class MintArkIdentifierNode extends MintArkIdentifier { }

--- a/modules/dgi_actions_ezid/src/Plugin/ServiceDataType/Ezid.php
+++ b/modules/dgi_actions_ezid/src/Plugin/ServiceDataType/Ezid.php
@@ -78,8 +78,8 @@ class Ezid extends ServiceDataTypeBase {
     ];
     $form['namespace'] = [
       '#type' => 'textfield',
-      '#title' => $this->t('Namespace'),
-      '#description' => $this->t('Client namespace for the Identifier.'),
+      '#title' => $this->t('Shoulder'),
+      '#description' => $this->t('EZID shoulder for minting the Identifier. E.g. `ark:/99999/fk4`.'),
       '#default_value' => $this->configuration['namespace'],
       '#required' => TRUE,
     ];

--- a/src/Plugin/Action/MintIdentifier.php
+++ b/src/Plugin/Action/MintIdentifier.php
@@ -4,6 +4,7 @@ namespace Drupal\dgi_actions\Plugin\Action;
 
 use Drupal\Core\Entity\FieldableEntityInterface;
 use Drupal\Core\Entity\Exception\UndefinedLinkTemplateException;
+use Drupal\Core\Field\EntityReferenceFieldItemList;
 use Drupal\Core\Form\FormStateInterface;
 
 /**
@@ -28,7 +29,11 @@ abstract class MintIdentifier extends IdentifierAction {
     if ($data_profile) {
       foreach ($data_profile->getData() as $key => $field) {
         if ($this->entity->hasField($field)) {
-          $data[$key] = $this->entity->get($field)->getString();
+          if ($this->entity->get($field) instanceof EntityReferenceFieldItemList) {
+            $data[$key] = $this->entity->get($field)->entity->label();
+          } else {
+            $data[$key] = $this->entity->get($field)->getString();
+          }
         }
       }
     }

--- a/src/Plugin/Action/MintIdentifier.php
+++ b/src/Plugin/Action/MintIdentifier.php
@@ -29,10 +29,15 @@ abstract class MintIdentifier extends IdentifierAction {
     if ($data_profile) {
       foreach ($data_profile->getData() as $key => $field) {
         if ($this->entity->hasField($field)) {
-          if ($this->entity->get($field) instanceof EntityReferenceFieldItemList) {
-            $data[$key] = $this->entity->get($field)->entity->label();
-          } else {
-            $data[$key] = $this->entity->get($field)->getString();
+          $entity_field = $this->entity->get($field);
+          if ($entity_field->isEmpty()) {
+            continue;
+          }
+          if ($entity_field instanceof EntityReferenceFieldItemList) {
+            $data[$key] = $entity_field->entity->label();
+          }
+          else {
+            $data[$key] = $entity_field->getString();
           }
         }
       }
@@ -114,6 +119,20 @@ abstract class MintIdentifier extends IdentifierAction {
   }
 
   /**
+   * Adds the `save_entity` configuration option.
+   *
+   * This option, when true, will save the entity as part of the action.
+   *
+   * The default FALSE option is for when the action is triggered
+   * as a context reaction.
+   */
+  public function defaultConfiguration(): array {
+    return parent::defaultConfiguration() + [
+      'save_entity' => FALSE,
+    ];
+  }
+
+  /**
    * {@inheritdoc}
    */
   public function buildConfigurationForm(array $form, FormStateInterface $form_state): array {
@@ -121,7 +140,7 @@ abstract class MintIdentifier extends IdentifierAction {
     $form['save_entity'] = [
       '#type' => 'checkbox',
       '#title' => $this->t('Save Entity'),
-      '#default_value' => ($this->configuration['save_entity']) ?: false,
+      '#default_value' => $this->configuration['save_entity'],
       '#description' => $this->t('Save the entity when populating the identifier field. Do not use if triggering from a hook or context reaction!'),
     ];
 
@@ -132,6 +151,7 @@ abstract class MintIdentifier extends IdentifierAction {
    * {@inheritdoc}
    */
   public function submitConfigurationForm(array &$form, FormStateInterface $form_state): void {
+    parent::submitConfigurationForm($form, $form_state);
     $this->configuration['save_entity'] = $form_state->getValue('save_entity');
   }
 


### PR DESCRIPTION
Add configurable EZID action for minting ARKs from content page (#28)

Also includes EZID Service Data Type form update to clarify namespace configuration (#27).