### PR TITLE
Makes the EZID status and resolver configurable (Issue-31)

### DIFF
--- a/modules/dgi_actions_ark_identifier/src/Plugin/Action/MintArkIdentifier.php
+++ b/modules/dgi_actions_ark_identifier/src/Plugin/Action/MintArkIdentifier.php
@@ -3,6 +3,7 @@
 namespace Drupal\dgi_actions_ark_identifier\Plugin\Action;
 
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Form\FormStateInterface;
 use Drupal\dgi_actions\Plugin\Action\HttpActionMintTrait;
 use Drupal\dgi_actions\Plugin\Action\MintIdentifier;
 use Drupal\dgi_actions\Utility\IdentifierUtils;
@@ -85,7 +86,7 @@ class MintArkIdentifier extends MintIdentifier {
     $data = array_merge(
       [
         '_target' => $this->getExternalUrl(),
-        '_status' => 'reserved',
+        '_status' => $this->configuration['status'],
       ], $data
     );
     return $this->buildEzidRequestBody($data);
@@ -141,6 +142,44 @@ class MintArkIdentifier extends MintIdentifier {
       ],
       'body' => $body,
     ];
+  }
+
+  /**
+   * Adds the `save_entity` configuration option.
+   *
+   * This option, when true, will save the entity as part of the action.
+   *
+   * The default FALSE option is for when the action is triggered
+   * as a context reaction.
+   */
+  public function defaultConfiguration(): array {
+    return parent::defaultConfiguration() + [
+      'status' => 'reserved',
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state): array {
+    $form = parent::buildConfigurationForm($form, $form_state);
+    $form['status'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Status'),
+      '#default_value' => $this->configuration['status'],
+      '#options' => ['public' => 'public','reserved' => 'reserved','unavailable' => 'unavailable'],
+      '#description' => $this->t("Set the identifier's status. This impacts the ARK's resolvability. See the EZID API documentation (https://ezid.cdlib.org/doc/apidoc.html#identifier-status)."),
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitConfigurationForm(array &$form, FormStateInterface $form_state): void {
+    parent::submitConfigurationForm($form, $form_state);
+    $this->configuration['status'] = $form_state->getValue('status');
   }
 
 }

--- a/modules/dgi_actions_ark_identifier/src/Plugin/Action/MintArkIdentifier.php
+++ b/modules/dgi_actions_ark_identifier/src/Plugin/Action/MintArkIdentifier.php
@@ -104,7 +104,10 @@ class MintArkIdentifier extends MintIdentifier {
         '@id' => $this->getEntity()->id(),
         '@contents' => $contents,
       ]);
-      return "{$this->getIdentifier()->getServiceData()->getData()['host']}/id/{$response['success']}";
+      $ark = $response['success'];
+      $service_data = $this->getIdentifier()->getServiceData()->getData();
+      $resolver = (array_key_exists('resolver', $service_data)) ? $service_data['resolver'] : "{$service_data['host']}/id";
+      return "{$resolver}/{$ark}";
     }
     throw new \Exception('There was an issue minting the ARK Identifier for @type/@id: @contents', [
       '@type' => $this->getEntity()->getEntityTypeId(),
@@ -163,11 +166,16 @@ class MintArkIdentifier extends MintIdentifier {
    */
   public function buildConfigurationForm(array $form, FormStateInterface $form_state): array {
     $form = parent::buildConfigurationForm($form, $form_state);
+    $status_options = [
+      'public' => 'public',
+      'reserved' => 'reserved',
+      'unavailable' => 'unavailable',
+    ];
     $form['status'] = [
       '#type' => 'select',
       '#title' => $this->t('Status'),
       '#default_value' => $this->configuration['status'],
-      '#options' => ['public' => 'public','reserved' => 'reserved','unavailable' => 'unavailable'],
+      '#options' => $status_options,
       '#description' => $this->t("Set the identifier's status. This impacts the ARK's resolvability. See the EZID API documentation (https://ezid.cdlib.org/doc/apidoc.html#identifier-status)."),
     ];
 

--- a/modules/dgi_actions_ark_identifier/src/Plugin/Action/MintArkIdentifier.php
+++ b/modules/dgi_actions_ark_identifier/src/Plugin/Action/MintArkIdentifier.php
@@ -106,7 +106,7 @@ class MintArkIdentifier extends MintIdentifier {
       ]);
       $ark = $response['success'];
       $service_data = $this->getIdentifier()->getServiceData()->getData();
-      $resolver = (array_key_exists('resolver', $service_data)) ? $service_data['resolver'] : "{$service_data['host']}/id";
+      $resolver = (array_key_exists('resolver', $service_data) && !empty($service_data['resolver'])) ? $service_data['resolver'] : "{$service_data['host']}/id";
       return "{$resolver}/{$ark}";
     }
     throw new \Exception('There was an issue minting the ARK Identifier for @type/@id: @contents', [

--- a/modules/dgi_actions_ezid/config/schema/dgi_actions_ezid.schema.yml
+++ b/modules/dgi_actions_ezid/config/schema/dgi_actions_ezid.schema.yml
@@ -18,6 +18,10 @@ dgi_actions.service_data_type.ezid:
       label: 'Namespace'
       type: string
       description: 'Client namespace for the Identifier.'
+    resolver:
+      label: 'Resolver'
+      type: string
+      description: 'Host address for the EZID resolver.'
 
 dgi_actions.data_profile_type.erc:
   type: mapping

--- a/modules/dgi_actions_ezid/src/Plugin/ServiceDataType/Ezid.php
+++ b/modules/dgi_actions_ezid/src/Plugin/ServiceDataType/Ezid.php
@@ -47,6 +47,7 @@ class Ezid extends ServiceDataTypeBase {
       'username' => NULL,
       'password' => NULL,
       'namespace' => NULL,
+      'resolver' => '',
     ];
   }
 
@@ -82,6 +83,12 @@ class Ezid extends ServiceDataTypeBase {
       '#description' => $this->t('EZID shoulder for minting the Identifier. E.g. `ark:/99999/fk4`.'),
       '#default_value' => $this->configuration['namespace'],
       '#required' => TRUE,
+    ];
+    $form['resolver'] = [
+      '#type' => 'url',
+      '#title' => $this->t('Resolver'),
+      '#description' => $this->t('Host address for the EZID resolver. (Falls back to the EZID Host plus "/id".)'),
+      '#default_value' => $this->configuration['resolver'],
     ];
     return $form;
   }


### PR DESCRIPTION
Addresses both the issues identified in https://github.com/discoverygarden/dgi_actions/issues/31 by making the ARK `_status` property and the EZID service resolver configurable.

Tagging @jordandukart 