### PR TITLE
AUCIR-281: Addressing coding standards from Lint

### DIFF
--- a/modules/dgi_actions_handle/src/Drush/Commands/HandleCommands.php
+++ b/modules/dgi_actions_handle/src/Drush/Commands/HandleCommands.php
@@ -134,11 +134,13 @@ class HandleCommands extends DrushCommands {
    * @usage dgi_actions_handle:update --handle=123/abc --target_location=http://google.ca --identifier_id=handle
    *   Updates a Handle.
    */
-  public function update(array $options = [
-    'handle' => self::REQ,
-    'target_location' => self::REQ,
-    'identifier_id' => self::OPT,
-  ]): void {
+  public function update(
+    array $options = [
+      'handle' => self::REQ,
+      'target_location' => self::REQ,
+      'identifier_id' => self::OPT,
+    ],
+  ): void {
     // If an identifier ID wasn't passed and validation didn't fail go grab
     // the default.
     if (!$options['identifier_id']) {

--- a/src/Drush/Commands/Generate.php
+++ b/src/Drush/Commands/Generate.php
@@ -136,10 +136,12 @@ class Generate extends DrushCommands {
    *   Generates missing identifiers for the entities with IDs of 1, 2, or 3 for
    *   the "handle" DGI Actions Identifier entity.
    */
-  public function generate(array $options = [
-    'identifier_id' => self::REQ,
-    'ids' => self::OPT,
-  ]): void {
+  public function generate(
+    array $options = [
+      'identifier_id' => self::REQ,
+      'ids' => self::OPT,
+    ],
+  ): void {
     $identifier = $this->entityTypeManager->getStorage('dgiactions_identifier')->load($options['identifier_id']);
     $ids = $options['ids'];
     $batch = [

--- a/src/Drush/Commands/PrintMissingEntityIds.php
+++ b/src/Drush/Commands/PrintMissingEntityIds.php
@@ -74,9 +74,11 @@ class PrintMissingEntityIds extends DrushCommands {
    *   Prints entity IDs by searching all entities for the "handle"
    *   DGI Actions Identifier entity.
    */
-  public function printIds(array $options = [
-    'identifier_id' => self::REQ,
-  ]) {
+  public function printIds(
+    array $options = [
+      'identifier_id' => self::REQ,
+    ],
+  ) {
     $identifier = $this->entityTypeManager->getStorage('dgiactions_identifier')->load($options['identifier_id']);
 
     $entity_type = $identifier->get('entity');

--- a/src/Plugin/Action/IdentifierAction.php
+++ b/src/Plugin/Action/IdentifierAction.php
@@ -72,12 +72,13 @@ abstract class IdentifierAction extends ConfigurableActionBase implements Contai
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The entity type manager.
    */
-  public function __construct(array $configuration,
+  public function __construct(
+    array $configuration,
     $plugin_id,
     $plugin_definition,
     LoggerInterface $logger,
     IdentifierUtils $utils,
-    EntityTypeManagerInterface $entity_type_manager
+    EntityTypeManagerInterface $entity_type_manager,
   ) {
 
     parent::__construct($configuration, $plugin_id, $plugin_definition);
@@ -104,7 +105,7 @@ abstract class IdentifierAction extends ConfigurableActionBase implements Contai
   /**
    * {@inheritdoc}
    */
-  public function access($object, AccountInterface $account = NULL, $return_as_object = FALSE) {
+  public function access($object, ?AccountInterface $account = NULL, $return_as_object = FALSE) {
     return $object->access('read', $account, $return_as_object);
   }
 

--- a/src/Plugin/Condition/EntityHasIdentifier.php
+++ b/src/Plugin/Condition/EntityHasIdentifier.php
@@ -77,7 +77,7 @@ class EntityHasIdentifier extends ConditionPluginBase implements ContainerFactor
     $plugin_definition,
     LoggerInterface $logger,
     EntityTypeManagerInterface $entity_type_manager,
-    IdentifierUtils $utils
+    IdentifierUtils $utils,
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->logger = $logger;

--- a/src/Utility/IdentifierUtils.php
+++ b/src/Utility/IdentifierUtils.php
@@ -34,7 +34,7 @@ class IdentifierUtils {
    */
   public function __construct(
     EntityTypeManagerInterface $entity_type_manager,
-    LoggerInterface $logger
+    LoggerInterface $logger,
   ) {
     $this->entityTypeManager = $entity_type_manager;
     $this->logger = $logger;


### PR DESCRIPTION
This PR is specifically addressing error output in a Lint pass. Posting below for reference:
```
FILE: /home/runner/work/dgi_actions/dgi_actions/src/Utility/IdentifierUtils.php
--------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
--------------------------------------------------------------------------------
 37 | ERROR | [x] Multi-line function declarations must have a trailing comma
    |       |     after the last parameter
    |       |     (Drupal.Functions.MultiLineFunctionDeclaration.MissingTrailingComma)
--------------------------------------------------------------------------------
PHPCBF CAN FIX THE 1 MARKED SNIFF VIOLATIONS AUTOMATICALLY
--------------------------------------------------------------------------------


FILE: .../work/dgi_actions/dgi_actions/src/Drush/Commands/PrintMissingEntityIds.php
--------------------------------------------------------------------------------
FOUND 3 ERRORS AFFECTING 2 LINES
--------------------------------------------------------------------------------
 77 | ERROR | [x] The first parameter of a multi-line function declaration must
    |       |     be on the line after the opening bracket
    |       |     (Drupal.Functions.MultiLineFunctionDeclaration.FirstParamSpacing)
 79 | ERROR | [x] Multi-line function declarations must have a trailing comma
    |       |     after the last parameter
    |       |     (Drupal.Functions.MultiLineFunctionDeclaration.MissingTrailingComma)
 79 | ERROR | [x] The closing parenthesis of a multi-line function declaration
    |       |     must be on a new line
    |       |     (Drupal.Functions.MultiLineFunctionDeclaration.CloseBracketLine)
--------------------------------------------------------------------------------
PHPCBF CAN FIX THE 3 MARKED SNIFF VIOLATIONS AUTOMATICALLY
--------------------------------------------------------------------------------


FILE: /home/runner/work/dgi_actions/dgi_actions/src/Drush/Commands/Generate.php
--------------------------------------------------------------------------------
FOUND 3 ERRORS AFFECTING 2 LINES
--------------------------------------------------------------------------------
 139 | ERROR | [x] The first parameter of a multi-line function declaration
     |       |     must be on the line after the opening bracket
     |       |     (Drupal.Functions.MultiLineFunctionDeclaration.FirstParamSpacing)
 142 | ERROR | [x] Multi-line function declarations must have a trailing comma
     |       |     after the last parameter
     |       |     (Drupal.Functions.MultiLineFunctionDeclaration.MissingTrailingComma)
 142 | ERROR | [x] The closing parenthesis of a multi-line function declaration
     |       |     must be on a new line
     |       |     (Drupal.Functions.MultiLineFunctionDeclaration.CloseBracketLine)
--------------------------------------------------------------------------------
PHPCBF CAN FIX THE 3 MARKED SNIFF VIOLATIONS AUTOMATICALLY
--------------------------------------------------------------------------------


FILE: .../work/dgi_actions/dgi_actions/src/Plugin/Condition/EntityHasIdentifier.php
--------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
--------------------------------------------------------------------------------
 80 | ERROR | [x] Multi-line function declarations must have a trailing comma
    |       |     after the last parameter
    |       |     (Drupal.Functions.MultiLineFunctionDeclaration.MissingTrailingComma)
--------------------------------------------------------------------------------
PHPCBF CAN FIX THE 1 MARKED SNIFF VIOLATIONS AUTOMATICALLY
--------------------------------------------------------------------------------


FILE: ...runner/work/dgi_actions/dgi_actions/src/Plugin/Action/IdentifierAction.php
--------------------------------------------------------------------------------
FOUND 3 ERRORS AFFECTING 3 LINES
--------------------------------------------------------------------------------
  [75](https://github.com/discoverygarden/dgi_actions/actions/runs/14090202076/job/39464697404?pr=53#step:3:79) | ERROR | [x] The first parameter of a multi-line function declaration
     |       |     must be on the line after the opening bracket
     |       |     (Drupal.Functions.MultiLineFunctionDeclaration.FirstParamSpacing)
  80 | ERROR | [x] Multi-line function declarations must have a trailing comma
     |       |     after the last parameter
     |       |     (Drupal.Functions.MultiLineFunctionDeclaration.MissingTrailingComma)
 107 | ERROR | [x] Parameter $account has null default value, but is not marked
     |       |     as nullable.
     |       |     (SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue.NullabilityTypeMissing)
--------------------------------------------------------------------------------
PHPCBF CAN FIX THE 3 MARKED SNIFF VIOLATIONS AUTOMATICALLY
--------------------------------------------------------------------------------


FILE: ...i_actions/modules/dgi_actions_handle/src/Drush/Commands/HandleCommands.php
--------------------------------------------------------------------------------
FOUND 3 ERRORS AFFECTING 2 LINES
--------------------------------------------------------------------------------
 137 | ERROR | [x] The first parameter of a multi-line function declaration
     |       |     must be on the line after the opening bracket
     |       |     (Drupal.Functions.MultiLineFunctionDeclaration.FirstParamSpacing)
 141 | ERROR | [x] Multi-line function declarations must have a trailing comma
     |       |     after the last parameter
     |       |     (Drupal.Functions.MultiLineFunctionDeclaration.MissingTrailingComma)
 141 | ERROR | [x] The closing parenthesis of a multi-line function declaration
     |       |     must be on a new line
     |       |     (Drupal.Functions.MultiLineFunctionDeclaration.CloseBracketLine)
--------------------------------------------------------------------------------
PHPCBF CAN FIX THE 3 MARKED SNIFF VIOLATIONS AUTOMATICALLY
--------------------------------------------------------------------------------
```