### PR TITLE
SEC-2592: Elevate minting failure log to error level

### DIFF
--- a/src/Plugin/Action/MintIdentifier.php
+++ b/src/Plugin/Action/MintIdentifier.php
@@ -95,7 +95,7 @@ abstract class MintIdentifier extends IdentifierAction {
         }
       }
       catch (UndefinedLinkTemplateException $ulte) {
-        $this->logger->warning('Minting failed for @type/@id: Error retrieving Entity URL: @errorMessage', [
+        $this->logger->error('Minting failed for @type/@id: Error retrieving Entity URL: @errorMessage', [
           '@type' => $this->getEntity()->getEntityTypeId(),
           '@id' => $this->getEntity()->id(),
           '@errorMessage' => $ulte->getMessage(),


### PR DESCRIPTION
## Summary
- Changes the `UndefinedLinkTemplateException` catch block in `MintIdentifier::execute()` from `warning` to `error` log level
- All minting failure paths now consistently emit `error`-level entries, ensuring Grafana/Loki alerts on `Minting failed for` fire as expected

## Test plan
- [ ] Confirm a minting failure produces an `error`-level watchdog entry matching `Minting failed for <type>/<id>: ...`
- [ ] Confirm the Grafana alert triggers on such an entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced error reporting severity for identifier URL retrieval failures to improve monitoring and troubleshooting of mint operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->