### PR TITLE
[AUC2-409, UCONN2-979]: Allow users to overwrite handles on the handle server when changing them in Drupal

### DIFF
--- a/modules/dgi_actions_handle/config/schema/dgi_actions_handle.schema.yml
+++ b/modules/dgi_actions_handle/config/schema/dgi_actions_handle.schema.yml
@@ -23,6 +23,10 @@ dgi_actions.service_data_type.handle:
       label: 'Suffix'
       type: string
       description: 'Field to use as handle suffix.'
+    overwrite:
+      label: 'Overwrite handles?'
+      type: boolean
+      description: 'Selecting this will cause items to delete old handles and mint new ones on the handle server when changing the handle in Drupal.'
 
 action.configuration.dgi_actions_delete_handle:
   type: dgi_actions_action_delete_base

--- a/modules/dgi_actions_handle/src/Plugin/Action/MintHandle.php
+++ b/modules/dgi_actions_handle/src/Plugin/Action/MintHandle.php
@@ -88,7 +88,7 @@ class MintHandle extends MintIdentifier {
         ],
       ],
       'query' => [
-        'overwrite' => $this->getIdentifier()->getServiceData()->getData()['overwrite'] ? 'true' : 'false',
+        'overwrite' => ($this->getIdentifier()->getServiceData()->getData()['overwrite'] ?? FALSE) ? 'true' : 'false',
       ],
     ];
   }

--- a/modules/dgi_actions_handle/src/Plugin/Action/MintHandle.php
+++ b/modules/dgi_actions_handle/src/Plugin/Action/MintHandle.php
@@ -88,7 +88,7 @@ class MintHandle extends MintIdentifier {
         ],
       ],
       'query' => [
-        'overwrite' => 'false',
+        'overwrite' => $this->getIdentifier()->getServiceData()->getData()['overwrite'] ? 'true' : 'false',
       ],
     ];
   }

--- a/modules/dgi_actions_handle/src/Plugin/ServiceDataType/Handle.php
+++ b/modules/dgi_actions_handle/src/Plugin/ServiceDataType/Handle.php
@@ -41,6 +41,7 @@ class Handle extends ServiceDataTypeBase {
       'password' => NULL,
       'prefix' => NULL,
       'suffix_field' => NULL,
+      'overwrite' => FALSE,
     ];
   }
 
@@ -108,6 +109,7 @@ class Handle extends ServiceDataTypeBase {
     $this->configuration['prefix'] = $form_state->getValue('prefix');
     $this->configuration['username'] = $form_state->getValue('username');
     $this->configuration['suffix_field'] = $form_state->getValue('suffix_field');
+    $this->configuration['overwrite'] = $form_state->getValue('overwrite');
     $this->configuration['password'] = !empty($form_state->getValue('password')) ? $form_state->getValue('password') : $this->configuration['password'];
     // Handle the scenario where the user did not modify the password as this
     // gets stored on the entity.

--- a/modules/dgi_actions_handle/src/Plugin/ServiceDataType/Handle.php
+++ b/modules/dgi_actions_handle/src/Plugin/ServiceDataType/Handle.php
@@ -77,6 +77,12 @@ class Handle extends ServiceDataTypeBase {
       '#default_value' => $this->configuration['prefix'],
       '#required' => TRUE,
     ];
+    $form['overwrite'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Overwrite Handles?'),
+      '#description' => $this->t('If new handles are saved in Drupal, should the old values on the handle server be overwritten?'),
+      '#default_value' => $this->configuration['overwrite'] ?? FALSE,
+    ];
     $form['suffix_field'] = [
       '#type' => 'hidden',
       '#default_value' => $this->configuration['suffix_field'],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “Overwrite Handles?” option to Handle.net configuration.
  * When enabled, changing a handle value deletes the existing handle and mints a new one.
  * The option is disabled by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->